### PR TITLE
Work around browser import of brain.js

### DIFF
--- a/lib/classifier.js
+++ b/lib/classifier.js
@@ -1,4 +1,6 @@
-const brain = require('brain.js');
+const _brain = require('brain.js');
+const brain = (Object.keys(_brain).length === 0 && typeof window !== 'undefined')
+  ? window.brain : _brain;
 const max = require('lodash.maxby');
 
 module.exports = class Classifier {


### PR DESCRIPTION
This is a workaround for browser builds to work until https://github.com/BrainJS/brain.js/pull/124 is merged.